### PR TITLE
Update plex.md

### DIFF
--- a/docker/faq/plex.md
+++ b/docker/faq/plex.md
@@ -50,7 +50,7 @@
 
 **Q3.** How do I configure Plex to use my GPU for encoding/decoding (sometimes referred to as hardware transcoding)?
 
-**A3.** To enable GPU encoding/decoding within Plex you need to install the 'Nvidia Driver' Plugin and then configure the Plex container as follows:-
+**A3.1** NVIDIA: To enable GPU encoding/decoding within Plex you need to install the 'Nvidia Driver' Plugin and then configure the Plex container as follows:-
 
 1. Go to Community Applications in the unRAID web ui and search for Plugin 'Nvidia Driver' and install it, then reboot host.
 2. Go to unRAID web ui/Plugins/Nvidia Driver and make a note of the GPU device, it should look something like this:- ```GPU-02ff3633-4f22-c4d6-2c15-654ff33a321e```
@@ -61,8 +61,25 @@
 7. Go to variable named 'NVIDIA_VISIBLE_DEVICES' and set the value to the GPU device found in step 2.
 8. Start Plex container.
 
+**A3.2** Intel HD Graphics: To enable GPU encoding/decoding within Plex you need to install the 'Nvidia Driver' Plugin and then configure the Plex container as follows:-
+
+1. Go to Community Applications in the unRAID web ui and search for Plugin 'Intel GPU TOP' and install it, then reboot host.
+2. Go to unRAID web ui/Docker tab/left click Plex container and select 'edit'.
+3. Click on the toggle for 'advanced view'.
+4. Go to 'Extra Parameters:' and set it to ```--device='/dev/dri```
+5. Start Plex container.
+
 **Notes**<br/>
-It is possible that the variables mentioned above do not exist in your template, if this is the case then please create them by doing the following:-
+1) GPU-Selection: You may have to select the corresponding GPU inside your Plex server settings. 
+
+1. Go to unRAID web ui/Docker tab/left click Plex container and select 'WebGUI'.
+2. Inside the left menu under 'Settings', click on the menu entry 'Transcoder'.
+3. Scroll to the most-bottom.
+4. At 'Device for Hardware-Transcoding', activate the dropdown menu and select your GPU (e.g. ```HD Graphics 630```).
+
+If set to ```Auto```, it may primarily utilize your devices CPU instead of the GPU.
+
+2) Template Variables: It is possible that the variables mentioned above do not exist in your template, if this is the case then please create them by doing the following:-
 
 1. Go to unRAID web ui/Docker tab/left click Plex container and select 'edit'
 2. Click on the toggle for 'advanced view'


### PR DESCRIPTION
Added instructions to utilize Intel HD Graphic GPUs. Extended the corresponding note section for instructions to select the GPU instead of the Auto setting. Users reported online that if on Auto, the CPU is utilized instead of the GPU.